### PR TITLE
Set default configuration to retry connection forever

### DIFF
--- a/examples/common/mqtt_agent/mqtt_agent_task.c
+++ b/examples/common/mqtt_agent/mqtt_agent_task.c
@@ -112,8 +112,10 @@
 
 /**
  * @brief The maximum number of retries for network operation with server.
+ * The configuration is set to retry forever. MQTT agent will retry in an infinite loop until
+ * its connected to broker.
  */
-#define RETRY_MAX_ATTEMPTS                           ( 20U )
+#define RETRY_MAX_ATTEMPTS                           ( BACKOFF_ALGORITHM_RETRY_FOREVER )
 
 /**
  * @brief The maximum back-off delay (in milliseconds) for retrying failed operation


### PR DESCRIPTION
Description
-----------

MQTT agent task currently performs reconnection in a loop but for up to a configured number of retries. Once retries are exhausted, agent breaks out of loop. Changing the default behavior to retry for ever to account for long disconnects.


Test Steps
-----------
Tested with Device advisor MQTT Jitter Connect retries test.

Related Issue
-----------
None

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.