### PR TITLE
demos: Make alpn identifiers work with mbedtls

### DIFF
--- a/examples/common/mqtt_agent/mqtt_agent_task.c
+++ b/examples/common/mqtt_agent/mqtt_agent_task.c
@@ -180,6 +180,23 @@
  */
 #define mqttexampleEVENT_BITS_ALL    ( ( EventBits_t ) ( ( 1ULL << MQTT_AGENT_NUM_STATES ) - 1U ) )
 
+
+/**
+ * @brief ALPN (Application-Layer Protocol Negotiation) protocol name for AWS IoT MQTT.
+ *
+ * This will be used if democonfigMQTT_BROKER_PORT is configured as 443 for the AWS IoT MQTT broker.
+ * Please see more details about the ALPN protocol for AWS IoT MQTT endpoint
+ * in the link below.
+ * https://aws.amazon.com/blogs/iot/mqtt-with-tls-client-authentication-on-port-443-why-it-is-useful-and-how-it-works/
+ */
+#define AWS_IOT_ALPN_MQTT_CA_AUTH        "x-amzn-mqtt-ca"
+
+/**
+ * @brief This is the ALPN (Application-Layer Protocol Negotiation) string
+ * required by AWS IoT for password-based authentication using TCP port 443.
+ */
+#define AWS_IOT_ALPN_MQTT_CUSTOM_AUTH    "mqtt"
+
 /*-----------------------------------------------------------*/
 
 /**
@@ -516,15 +533,13 @@ static BaseType_t prvCreateTLSConnection( NetworkContext_t * pxNetworkContext )
     /* ALPN protocols must be a NULL-terminated list of strings. Therefore,
      * the first entry will contain the actual ALPN protocol string while the
      * second entry must remain NULL. */
-    const char * pcAlpnProtocols[] = { NULL, NULL };
-
-    /* The ALPN string changes depending on whether username/password authentication is used. */
 #ifdef democonfigCLIENT_USERNAME
-    pcAlpnProtocols[ 0 ] = AWS_IOT_CUSTOM_AUTH_ALPN;
+    static const char * ppcAlpnProtocols[] = { AWS_IOT_ALPN_MQTT_CUSTOM_AUTH, NULL };
 #else
-    pcAlpnProtocols[ 0 ] = AWS_IOT_MQTT_ALPN;
+    static const char * ppcAlpnProtocols[] = { AWS_IOT_ALPN_MQTT_CA_AUTH, NULL };
 #endif
-    xNetworkCredentials.pAlpnProtos = pcAlpnProtocols;
+
+    xNetworkCredentials.pAlpnProtos = ppcAlpnProtocols;
 #endif /* ifdef democonfigUSE_AWS_IOT_CORE_BROKER */
 
     /* Set the credentials for establishing a TLS connection. */

--- a/examples/evkbmimxrt1060/defender/include/demo_config.h
+++ b/examples/evkbmimxrt1060/defender/include/demo_config.h
@@ -191,24 +191,7 @@
  * for an MQTT broker that only has an IP address but no hostname. However,
  * SNI should be enabled whenever possible.
  */
-#define democonfigDISABLE_SNI       ( pdFALSE )
-
-/**
- * @brief ALPN (Application-Layer Protocol Negotiation) protocol name for AWS IoT MQTT.
- *
- * This will be used if democonfigMQTT_BROKER_PORT is configured as 443 for the AWS IoT MQTT broker.
- * Please see more details about the ALPN protocol for AWS IoT MQTT endpoint
- * in the link below.
- * https://aws.amazon.com/blogs/iot/mqtt-with-tls-client-authentication-on-port-443-why-it-is-useful-and-how-it-works/
- */
-#define AWS_IOT_MQTT_ALPN           "\x0ex-amzn-mqtt-ca"
-
-/**
- * @brief This is the ALPN (Application-Layer Protocol Negotiation) string
- * required by AWS IoT for password-based authentication using TCP port 443.
- */
-#define AWS_IOT_CUSTOM_AUTH_ALPN    "\x04mqtt"
-
+#define democonfigDISABLE_SNI                ( pdFALSE )
 
 /**
  * @brief Configuration that indicates if the demo connection is made to the AWS IoT Core MQTT broker.

--- a/examples/evkbmimxrt1060/defender/include/demo_config.h
+++ b/examples/evkbmimxrt1060/defender/include/demo_config.h
@@ -259,30 +259,12 @@
 #include "core_mqtt.h" /* Include coreMQTT header for MQTT_LIBRARY_VERSION macro. */
 #define democonfigMQTT_LIB    "core-mqtt@"MQTT_LIBRARY_VERSION
 
-
 /**
  * @brief The MQTT metrics string expected by AWS IoT.
  */
 #define AWS_IOT_METRICS_STRING                                 \
     "?SDK=" democonfigOS_NAME "&Version=" democonfigOS_VERSION \
     "&Platform=" democonfigHARDWARE_PLATFORM_NAME "&MQTTLib=" democonfigMQTT_LIB
-
-/**
- * @brief The length of the MQTT metrics string expected by AWS IoT.
- */
-#define AWS_IOT_METRICS_STRING_LENGTH    ( ( uint16_t ) ( sizeof( AWS_IOT_METRICS_STRING ) - 1 ) )
-
-
-#ifdef democonfigCLIENT_USERNAME
-
-/**
- * @brief Append the username with the metrics string if #democonfigCLIENT_USERNAME is defined.
- *
- * This is to support both metrics reporting and username/password based client
- * authentication by AWS IoT.
- */
-#define CLIENT_USERNAME_WITH_METRICS    democonfigCLIENT_USERNAME AWS_IOT_METRICS_STRING
-#endif
 
 /**
  * @brief Size of the open TCP ports array.

--- a/examples/evkbmimxrt1060/pubsub/include/demo_config.h
+++ b/examples/evkbmimxrt1060/pubsub/include/demo_config.h
@@ -191,24 +191,7 @@
  * for an MQTT broker that only has an IP address but no hostname. However,
  * SNI should be enabled whenever possible.
  */
-#define democonfigDISABLE_SNI       ( pdFALSE )
-
-/**
- * @brief ALPN (Application-Layer Protocol Negotiation) protocol name for AWS IoT MQTT.
- *
- * This will be used if democonfigMQTT_BROKER_PORT is configured as 443 for the AWS IoT MQTT broker.
- * Please see more details about the ALPN protocol for AWS IoT MQTT endpoint
- * in the link below.
- * https://aws.amazon.com/blogs/iot/mqtt-with-tls-client-authentication-on-port-443-why-it-is-useful-and-how-it-works/
- */
-#define AWS_IOT_MQTT_ALPN           "\x0ex-amzn-mqtt-ca"
-
-/**
- * @brief This is the ALPN (Application-Layer Protocol Negotiation) string
- * required by AWS IoT for password-based authentication using TCP port 443.
- */
-#define AWS_IOT_CUSTOM_AUTH_ALPN    "\x04mqtt"
-
+#define democonfigDISABLE_SNI                ( pdFALSE )
 
 /**
  * @brief Configuration that indicates if the demo connection is made to the AWS IoT Core MQTT broker.

--- a/examples/evkbmimxrt1060/pubsub/include/demo_config.h
+++ b/examples/evkbmimxrt1060/pubsub/include/demo_config.h
@@ -259,32 +259,12 @@
 #include "core_mqtt.h" /* Include coreMQTT header for MQTT_LIBRARY_VERSION macro. */
 #define democonfigMQTT_LIB    "core-mqtt@"MQTT_LIBRARY_VERSION
 
-
 /**
  * @brief The MQTT metrics string expected by AWS IoT.
  */
 #define AWS_IOT_METRICS_STRING                                 \
     "?SDK=" democonfigOS_NAME "&Version=" democonfigOS_VERSION \
     "&Platform=" democonfigHARDWARE_PLATFORM_NAME "&MQTTLib=" democonfigMQTT_LIB
-
-/**
- * @brief The length of the MQTT metrics string expected by AWS IoT.
- */
-#define AWS_IOT_METRICS_STRING_LENGTH    ( ( uint16_t ) ( sizeof( AWS_IOT_METRICS_STRING ) - 1 ) )
-
-
-#ifdef democonfigCLIENT_USERNAME
-
-/**
- * @brief Append the username with the metrics string if #democonfigCLIENT_USERNAME is defined.
- *
- * This is to support both metrics reporting and username/password based client
- * authentication by AWS IoT.
- */
-#define CLIENT_USERNAME_WITH_METRICS    democonfigCLIENT_USERNAME AWS_IOT_METRICS_STRING
-#endif
-
-
 
 /**
  * @brief Set the stack size of the main demo task.
@@ -301,6 +281,5 @@
  * stack is created by an operating system thread.
  */
 #define democonfigDEMO_TASK_PRIORITY    ( tskIDLE_PRIORITY + 1 )
-
 
 #endif /* DEMO_CONFIG_H */

--- a/examples/evkbmimxrt1060/shadow/include/demo_config.h
+++ b/examples/evkbmimxrt1060/shadow/include/demo_config.h
@@ -191,24 +191,7 @@
  * for an MQTT broker that only has an IP address but no hostname. However,
  * SNI should be enabled whenever possible.
  */
-#define democonfigDISABLE_SNI       ( pdFALSE )
-
-/**
- * @brief ALPN (Application-Layer Protocol Negotiation) protocol name for AWS IoT MQTT.
- *
- * This will be used if democonfigMQTT_BROKER_PORT is configured as 443 for the AWS IoT MQTT broker.
- * Please see more details about the ALPN protocol for AWS IoT MQTT endpoint
- * in the link below.
- * https://aws.amazon.com/blogs/iot/mqtt-with-tls-client-authentication-on-port-443-why-it-is-useful-and-how-it-works/
- */
-#define AWS_IOT_MQTT_ALPN           "\x0ex-amzn-mqtt-ca"
-
-/**
- * @brief This is the ALPN (Application-Layer Protocol Negotiation) string
- * required by AWS IoT for password-based authentication using TCP port 443.
- */
-#define AWS_IOT_CUSTOM_AUTH_ALPN    "\x04mqtt"
-
+#define democonfigDISABLE_SNI                ( pdFALSE )
 
 /**
  * @brief Configuration that indicates if the demo connection is made to the AWS IoT Core MQTT broker.

--- a/examples/evkbmimxrt1060/shadow/include/demo_config.h
+++ b/examples/evkbmimxrt1060/shadow/include/demo_config.h
@@ -259,32 +259,12 @@
 #include "core_mqtt.h" /* Include coreMQTT header for MQTT_LIBRARY_VERSION macro. */
 #define democonfigMQTT_LIB    "core-mqtt@"MQTT_LIBRARY_VERSION
 
-
 /**
  * @brief The MQTT metrics string expected by AWS IoT.
  */
 #define AWS_IOT_METRICS_STRING                                 \
     "?SDK=" democonfigOS_NAME "&Version=" democonfigOS_VERSION \
     "&Platform=" democonfigHARDWARE_PLATFORM_NAME "&MQTTLib=" democonfigMQTT_LIB
-
-/**
- * @brief The length of the MQTT metrics string expected by AWS IoT.
- */
-#define AWS_IOT_METRICS_STRING_LENGTH    ( ( uint16_t ) ( sizeof( AWS_IOT_METRICS_STRING ) - 1 ) )
-
-
-#ifdef democonfigCLIENT_USERNAME
-
-/**
- * @brief Append the username with the metrics string if #democonfigCLIENT_USERNAME is defined.
- *
- * This is to support both metrics reporting and username/password based client
- * authentication by AWS IoT.
- */
-#define CLIENT_USERNAME_WITH_METRICS    democonfigCLIENT_USERNAME AWS_IOT_METRICS_STRING
-#endif
-
-
 
 /**
  * @brief Set the stack size of the main demo task.
@@ -301,6 +281,5 @@
  * stack is created by an operating system thread.
  */
 #define democonfigDEMO_TASK_PRIORITY    ( tskIDLE_PRIORITY + 1 )
-
 
 #endif /* DEMO_CONFIG_H */

--- a/examples/evkbmimxrt1060/test/include/demo_config.h
+++ b/examples/evkbmimxrt1060/test/include/demo_config.h
@@ -132,24 +132,7 @@
  * for an MQTT broker that only has an IP address but no hostname. However,
  * SNI should be enabled whenever possible.
  */
-#define democonfigDISABLE_SNI       ( pdFALSE )
-
-/**
- * @brief ALPN (Application-Layer Protocol Negotiation) protocol name for AWS IoT MQTT.
- *
- * This will be used if democonfigMQTT_BROKER_PORT is configured as 443 for the AWS IoT MQTT broker.
- * Please see more details about the ALPN protocol for AWS IoT MQTT endpoint
- * in the link below.
- * https://aws.amazon.com/blogs/iot/mqtt-with-tls-client-authentication-on-port-443-why-it-is-useful-and-how-it-works/
- */
-#define AWS_IOT_MQTT_ALPN           "\x0ex-amzn-mqtt-ca"
-
-/**
- * @brief This is the ALPN (Application-Layer Protocol Negotiation) string
- * required by AWS IoT for password-based authentication using TCP port 443.
- */
-#define AWS_IOT_CUSTOM_AUTH_ALPN    "\x04mqtt"
-
+#define democonfigDISABLE_SNI                ( pdFALSE )
 
 /**
  * @brief Configuration that indicates if the demo connection is made to the AWS IoT Core MQTT broker.

--- a/examples/evkbmimxrt1060/test/include/demo_config.h
+++ b/examples/evkbmimxrt1060/test/include/demo_config.h
@@ -200,32 +200,12 @@
 #include "core_mqtt.h" /* Include coreMQTT header for MQTT_LIBRARY_VERSION macro. */
 #define democonfigMQTT_LIB    "core-mqtt@"MQTT_LIBRARY_VERSION
 
-
 /**
  * @brief The MQTT metrics string expected by AWS IoT.
  */
 #define AWS_IOT_METRICS_STRING                                 \
     "?SDK=" democonfigOS_NAME "&Version=" democonfigOS_VERSION \
     "&Platform=" democonfigHARDWARE_PLATFORM_NAME "&MQTTLib=" democonfigMQTT_LIB
-
-/**
- * @brief The length of the MQTT metrics string expected by AWS IoT.
- */
-#define AWS_IOT_METRICS_STRING_LENGTH    ( ( uint16_t ) ( sizeof( AWS_IOT_METRICS_STRING ) - 1 ) )
-
-
-#ifdef democonfigCLIENT_USERNAME
-
-/**
- * @brief Append the username with the metrics string if #democonfigCLIENT_USERNAME is defined.
- *
- * This is to support both metrics reporting and username/password based client
- * authentication by AWS IoT.
- */
-#define CLIENT_USERNAME_WITH_METRICS    democonfigCLIENT_USERNAME AWS_IOT_METRICS_STRING
-#endif
-
-
 
 /**
  * @brief Set the stack size of the main demo task.
@@ -242,6 +222,5 @@
  * stack is created by an operating system thread.
  */
 #define democonfigDEMO_TASK_PRIORITY    ( tskIDLE_PRIORITY + 1 )
-
 
 #endif /* DEMO_CONFIG_H */

--- a/lexicon.txt
+++ b/lexicon.txt
@@ -876,6 +876,7 @@ wasn
 weierstrass
 whan
 www
+x-amzn-mqtt-ca
 xclass
 xcleansession
 xdatalength


### PR DESCRIPTION
* Move AWS IoT Core alpn identifiers from demo_config.h to
  mqtt_agent_task.c.
* Replace openssl formatted ALPN identifier strings with mbedtls
  compatible ALPN identifier strings.