### PR TITLE
[WIP] Fix OM-SE050ARD-E/-F Board Incompatability

### DIFF
--- a/Middleware/NXP/pkcs11/pkcs11.c
+++ b/Middleware/NXP/pkcs11/pkcs11.c
@@ -4237,6 +4237,8 @@ CK_DEFINE_FUNCTION(CK_RV, C_GetAttributeValue)
                 case kSSS_CipherType_RSA_CRT:
                     xP11KeyType = CKK_RSA;
                     break;
+                /* No way this works */
+                case kSSS_CipherType_EC_NIST_K:
                 case kSSS_CipherType_EC_NIST_P:
                     xP11KeyType = CKK_EC;
                     break;


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Trying out fixes to support the SE050ARD-E board. This quick attempt is to fix https://github.com/FreeRTOS/iot-reference-nxp-rt1060/issues/36

Test Steps
-----------
Not tested

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
